### PR TITLE
have map iterate hashes, also added pair? test

### DIFF
--- a/interpreter/environment.go
+++ b/interpreter/environment.go
@@ -312,13 +312,32 @@ func (env *Glisp) LoadExpressions(expressions []Sexp) error {
 	return nil
 }
 
+func (env *Glisp) ParseFile(file string) ([]Sexp, error) {
+	in, err := os.Open(file)
+	if err != nil {
+		return nil, err
+	}
+
+	lexer := NewLexerFromStream(bufio.NewReader(in))
+
+	var exp []Sexp
+
+	exp, err = ParseTokens(env, lexer)
+	if err != nil {
+		return nil, fmt.Errorf("Error on line %d: %v\n", lexer.Linenum(), err)
+	}
+
+	in.Close()
+
+	return exp, nil
+}
+
 func (env *Glisp) LoadStream(stream io.RuneReader) error {
 	lexer := NewLexerFromStream(stream)
 
 	expressions, err := ParseTokens(env, lexer)
 	if err != nil {
-		return errors.New(fmt.Sprintf(
-			"Error on line %d: %v\n", lexer.Linenum(), err))
+		return fmt.Errorf("Error on line %d: %v\n", lexer.Linenum(), err)
 	}
 
 	return env.LoadExpressions(expressions)

--- a/interpreter/environment.go
+++ b/interpreter/environment.go
@@ -383,6 +383,7 @@ func (env *Glisp) AddMacro(name string, function GlispUserFunction) {
 }
 
 func (env *Glisp) ImportEval() {
+	env.AddFunction("source-file", SourceFileFunction)
 	env.AddFunction("eval", EvalFunction)
 }
 

--- a/interpreter/environment.go
+++ b/interpreter/environment.go
@@ -483,6 +483,11 @@ func (env *Glisp) Run() (Sexp, error) {
 		}
 	}
 
+	if env.datastack.IsEmpty() {
+		env.DumpEnvironment()
+		os.Exit(-1)
+	}
+
 	return env.datastack.PopExpr()
 }
 

--- a/interpreter/expressions.go
+++ b/interpreter/expressions.go
@@ -74,7 +74,13 @@ func (pair SexpPair) SexpString() string {
 }
 
 type SexpArray []Sexp
-type SexpHash map[int][]SexpPair
+type SexpHash struct {
+	TypeName *string
+	Map      map[int][]SexpPair
+	KeyOrder *[]Sexp // must user pointers here, else hset! will fail to update.
+	GoStruct *interface{}
+	NumKeys  *int
+}
 type SexpInt int
 type SexpBool bool
 type SexpFloat float64
@@ -99,7 +105,7 @@ func (arr SexpArray) SexpString() string {
 
 func (hash SexpHash) SexpString() string {
 	str := "{"
-	for _, arr := range hash {
+	for _, arr := range hash.Map {
 		for _, pair := range arr {
 			str += pair.head.SexpString() + " "
 			str += pair.tail.SexpString() + " "
@@ -177,4 +183,12 @@ func IsTruthy(expr Sexp) bool {
 		return e != SexpNull
 	}
 	return true
+}
+
+type SexpStackmark struct {
+	sym SexpSymbol
+}
+
+func (mark SexpStackmark) SexpString() string {
+	return "stackmark " + mark.sym.name
 }

--- a/interpreter/functions.go
+++ b/interpreter/functions.go
@@ -397,6 +397,8 @@ func TypeQueryFunction(env *Glisp, name string, args []Sexp) (Sexp, error) {
 	switch name {
 	case "list?":
 		result = IsList(args[0])
+	case "pair?":
+		result = IsPair(args[0])
 	case "null?":
 		result = (args[0] == SexpNull)
 	case "array?":
@@ -505,8 +507,10 @@ func MapFunction(env *Glisp, name string, args []Sexp) (Sexp, error) {
 		return MapArray(env, fun, e)
 	case SexpPair:
 		return MapList(env, fun, e)
+	case SexpHash:
+		return MapHash(env, fun, e)
 	}
-	return SexpNull, errors.New("second argument must be array")
+	return SexpNull, errors.New("second argument must be array, list or hash")
 }
 
 func MakeArrayFunction(env *Glisp, name string, args []Sexp) (Sexp, error) {
@@ -672,6 +676,7 @@ var BuiltinFunctions = map[string]GlispUserFunction{
 	"string?":    TypeQueryFunction,
 	"zero?":      TypeQueryFunction,
 	"empty?":     TypeQueryFunction,
+	"pair?":      TypeQueryFunction,
 	"println":    PrintFunction,
 	"print":      PrintFunction,
 	"not":        NotFunction,

--- a/interpreter/functions.go
+++ b/interpreter/functions.go
@@ -257,17 +257,17 @@ func HashAccessFunction(env *Glisp, name string, args []Sexp) (Sexp, error) {
 	switch name {
 	case "hget":
 		if len(args) == 3 {
-			return HashGetDefault(hash, args[1], args[2])
+			return hash.HashGetDefault(args[1], args[2])
 		}
-		return HashGet(hash, args[1])
+		return hash.HashGet(args[1])
 	case "hset!":
-		err := HashSet(hash, args[1], args[2])
+		err := hash.HashSet(args[1], args[2])
 		return SexpNull, err
 	case "hdel!":
 		if len(args) != 2 {
 			return SexpNull, WrongNargs
 		}
-		err := HashDelete(hash, args[1])
+		err := hash.HashDelete(args[1])
 		return SexpNull, err
 	}
 
@@ -544,7 +544,7 @@ func ConstructorFunction(env *Glisp, name string, args []Sexp) (Sexp, error) {
 	case "list":
 		return MakeList(args), nil
 	case "hash":
-		return MakeHash(args)
+		return MakeHash(args, "hash")
 	}
 	return SexpNull, errors.New("invalid constructor")
 }
@@ -636,60 +636,69 @@ func MakeUserFunction(name string, ufun GlispUserFunction) SexpFunction {
 }
 
 var BuiltinFunctions = map[string]GlispUserFunction{
-	"<":           CompareFunction,
-	">":           CompareFunction,
-	"<=":          CompareFunction,
-	">=":          CompareFunction,
-	"=":           CompareFunction,
-	"not=":        CompareFunction,
-	"sll":         BinaryIntFunction,
-	"sra":         BinaryIntFunction,
-	"srl":         BinaryIntFunction,
-	"mod":         BinaryIntFunction,
-	"+":           NumericFunction,
-	"-":           NumericFunction,
-	"*":           NumericFunction,
-	"/":           NumericFunction,
-	"bit-and":     BitwiseFunction,
-	"bit-or":      BitwiseFunction,
-	"bit-xor":     BitwiseFunction,
-	"bit-not":     ComplementFunction,
-	"read":        ReadFunction,
-	"cons":        ConsFunction,
-	"first":       FirstFunction,
-	"rest":        RestFunction,
-	"car":         FirstFunction,
-	"cdr":         RestFunction,
-	"list?":       TypeQueryFunction,
-	"null?":       TypeQueryFunction,
-	"array?":      TypeQueryFunction,
-	"hash?":       TypeQueryFunction,
-	"number?":     TypeQueryFunction,
-	"int?":        TypeQueryFunction,
-	"float?":      TypeQueryFunction,
-	"char?":       TypeQueryFunction,
-	"symbol?":     TypeQueryFunction,
-	"string?":     TypeQueryFunction,
-	"zero?":       TypeQueryFunction,
-	"empty?":      TypeQueryFunction,
-	"println":     PrintFunction,
-	"print":       PrintFunction,
-	"not":         NotFunction,
-	"apply":       ApplyFunction,
-	"map":         MapFunction,
-	"make-array":  MakeArrayFunction,
-	"aget":        ArrayAccessFunction,
-	"aset!":       ArrayAccessFunction,
-	"sget":        SgetFunction,
-	"hget":        HashAccessFunction,
-	"hset!":       HashAccessFunction,
-	"hdel!":       HashAccessFunction,
-	"slice":       SliceFunction,
-	"len":         LenFunction,
-	"append":      AppendFunction,
-	"concat":      ConcatFunction,
-	"array":       ConstructorFunction,
-	"list":        ConstructorFunction,
-	"hash":        ConstructorFunction,
-	"symnum":      SymnumFunction,
+	"<":          CompareFunction,
+	">":          CompareFunction,
+	"<=":         CompareFunction,
+	">=":         CompareFunction,
+	"=":          CompareFunction,
+	"not=":       CompareFunction,
+	"sll":        BinaryIntFunction,
+	"sra":        BinaryIntFunction,
+	"srl":        BinaryIntFunction,
+	"mod":        BinaryIntFunction,
+	"+":          NumericFunction,
+	"-":          NumericFunction,
+	"*":          NumericFunction,
+	"/":          NumericFunction,
+	"bit-and":    BitwiseFunction,
+	"bit-or":     BitwiseFunction,
+	"bit-xor":    BitwiseFunction,
+	"bit-not":    ComplementFunction,
+	"read":       ReadFunction,
+	"cons":       ConsFunction,
+	"first":      FirstFunction,
+	"rest":       RestFunction,
+	"car":        FirstFunction,
+	"cdr":        RestFunction,
+	"list?":      TypeQueryFunction,
+	"null?":      TypeQueryFunction,
+	"array?":     TypeQueryFunction,
+	"hash?":      TypeQueryFunction,
+	"number?":    TypeQueryFunction,
+	"int?":       TypeQueryFunction,
+	"float?":     TypeQueryFunction,
+	"char?":      TypeQueryFunction,
+	"symbol?":    TypeQueryFunction,
+	"string?":    TypeQueryFunction,
+	"zero?":      TypeQueryFunction,
+	"empty?":     TypeQueryFunction,
+	"println":    PrintFunction,
+	"print":      PrintFunction,
+	"not":        NotFunction,
+	"apply":      ApplyFunction,
+	"map":        MapFunction,
+	"make-array": MakeArrayFunction,
+	"aget":       ArrayAccessFunction,
+	"aset!":      ArrayAccessFunction,
+	"sget":       SgetFunction,
+	"hget":       HashAccessFunction,
+	"hset!":      HashAccessFunction,
+	"hdel!":      HashAccessFunction,
+	"slice":      SliceFunction,
+	"len":        LenFunction,
+	"append":     AppendFunction,
+	"concat":     ConcatFunction,
+	"array":      ConstructorFunction,
+	"list":       ConstructorFunction,
+	"hash":       ConstructorFunction,
+	"symnum":     SymnumFunction,
+	"str":        StringifyFunction,
+}
+
+func StringifyFunction(env *Glisp, name string, args []Sexp) (Sexp, error) {
+	if len(args) != 1 {
+		return SexpNull, WrongNargs
+	}
+
+	return SexpStr(args[0].SexpString()), nil
 }

--- a/interpreter/functions.go
+++ b/interpreter/functions.go
@@ -378,14 +378,12 @@ func EvalFunction(env *Glisp, name string, args []Sexp) (Sexp, error) {
 	if len(args) != 1 {
 		return SexpNull, WrongNargs
 	}
-	newenv := NewGlisp()
-	gen := NewGenerator(newenv)
-	err := gen.Generate(args[0])
+	newenv := env.Duplicate()
+	err := newenv.LoadExpressions(args)
 	if err != nil {
 		return SexpNull, errors.New("failed to compile expression")
 	}
-	newenv.mainfunc = MakeFunction("__main", 0, false, gen.instructions)
-	newenv.pc = -1
+	newenv.pc = 0
 	return newenv.Run()
 }
 

--- a/interpreter/functions.go
+++ b/interpreter/functions.go
@@ -692,5 +692,4 @@ var BuiltinFunctions = map[string]GlispUserFunction{
 	"list":        ConstructorFunction,
 	"hash":        ConstructorFunction,
 	"symnum":      SymnumFunction,
-	"source-file": SourceFileFunction,
 }

--- a/interpreter/generator.go
+++ b/interpreter/generator.go
@@ -13,6 +13,16 @@ type Generator struct {
 	instructions []Instruction
 }
 
+type Loop struct {
+	stmtname       SexpSymbol
+	loopStart      int
+	loopLen        int
+	breakOffset    int // i.e. relative to loopStart
+	continueOffset int // i.e. relative to loopStart
+}
+
+func (loop *Loop) IsStackElem() {}
+
 func NewGenerator(env *Glisp) *Generator {
 	gen := new(Generator)
 	gen.env = env
@@ -332,50 +342,6 @@ func (gen *Generator) GenerateQuote(args []Sexp) error {
 	return nil
 }
 
-func (gen *Generator) GenerateSyntaxQuote(args []Sexp) error {
-	if len(args) != 1 {
-		return errors.New("syntax-quote takes 1 argument")
-	}
-
-	if args[0] == SexpNull || !IsList(args[0]) {
-		gen.AddInstruction(PushInstr{args[0]})
-		return nil
-	}
-	quotebody, _ := ListToArray(args[0])
-
-	if len(quotebody) == 2 {
-		var issymbol bool
-		var sym SexpSymbol
-		switch t := quotebody[0].(type) {
-		case SexpSymbol:
-			sym = t
-			issymbol = true
-		default:
-			issymbol = false
-		}
-		if issymbol {
-			if sym.name == "unquote" {
-				gen.Generate(quotebody[1])
-				return nil
-			} else if sym.name == "unquote-splicing" {
-				gen.Generate(quotebody[1])
-				gen.AddInstruction(ExplodeInstr(0))
-				return nil
-			}
-		}
-	}
-
-	gen.AddInstruction(PushInstr{SexpMarker})
-
-	for _, expr := range quotebody {
-		gen.GenerateSyntaxQuote([]Sexp{expr})
-	}
-
-	gen.AddInstruction(SquashInstr(0))
-
-	return nil
-}
-
 func (gen *Generator) GenerateLet(name string, args []Sexp) error {
 	if len(args) < 2 {
 		return errors.New("malformed let statement")
@@ -642,4 +608,142 @@ func (gen *Generator) Reset() {
 	gen.instructions = make([]Instruction, 0)
 	gen.tail = false
 	gen.scopes = 0
+}
+
+// side-effect (or main effect) has to be pushing an expression on the top of
+// the datastack that represents the expanded and substituted expression
+func (gen *Generator) GenerateSyntaxQuote(args []Sexp) error {
+
+	if len(args) != 1 {
+		return errors.New("syntax-quote takes exactly one argument")
+	}
+	arg := args[0]
+
+	// need to handle arrays, since they can have unquotes
+	// in them too.
+	switch arg.(type) {
+	case SexpArray:
+		gen.generateSyntaxQuoteArray(arg)
+		return nil
+	case SexpPair:
+		if !IsList(arg) {
+			break
+		}
+		gen.generateSyntaxQuoteList(arg)
+		return nil
+	case SexpHash:
+		gen.generateSyntaxQuoteHash(arg)
+		return nil
+	}
+	gen.AddInstruction(PushInstr{arg})
+	return nil
+}
+
+func (gen *Generator) generateSyntaxQuoteList(arg Sexp) error {
+
+	switch a := arg.(type) {
+	case SexpPair:
+		//good, required here
+	default:
+		return fmt.Errorf("arg to generateSyntaxQuoteList() must be list; got %T", a)
+	}
+
+	// things that need unquoting end up as
+	// (unquote mysym)
+	// i.e. a pair
+	// list of length 2 exactly, with first atom
+	// being "unquote" and second being the symbol
+	// to substitute.
+	quotebody, _ := ListToArray(arg)
+
+	if len(quotebody) == 2 {
+		var issymbol bool
+		var sym SexpSymbol
+		switch t := quotebody[0].(type) {
+		case SexpSymbol:
+			sym = t
+			issymbol = true
+		default:
+			issymbol = false
+		}
+		if issymbol {
+			if sym.name == "unquote" {
+				gen.Generate(quotebody[1])
+				return nil
+			} else if sym.name == "unquote-splicing" {
+				gen.Generate(quotebody[1])
+				gen.AddInstruction(ExplodeInstr(0))
+				return nil
+			}
+		}
+	}
+
+	gen.AddInstruction(PushInstr{SexpMarker})
+
+	for _, expr := range quotebody {
+		gen.GenerateSyntaxQuote([]Sexp{expr})
+	}
+
+	gen.AddInstruction(SquashInstr(0))
+
+	return nil
+}
+
+func (gen *Generator) generateSyntaxQuoteArray(arg Sexp) error {
+
+	var arr SexpArray
+	switch a := arg.(type) {
+	case SexpArray:
+		//good, required here
+		arr = a
+	default:
+		return fmt.Errorf("arg to generateSyntaxQuoteArray() must be an array; got %T", a)
+	}
+
+	gen.AddInstruction(PushInstr{SexpMarker})
+	for _, expr := range arr {
+		gen.AddInstruction(PushInstr{SexpMarker})
+		gen.GenerateSyntaxQuote([]Sexp{expr})
+		gen.AddInstruction(SquashInstr(0))
+		gen.AddInstruction(ExplodeInstr(0))
+	}
+	gen.AddInstruction(VectorizeInstr(0))
+	return nil
+}
+
+func (gen *Generator) generateSyntaxQuoteHash(arg Sexp) error {
+
+	var hash SexpHash
+	switch a := arg.(type) {
+	case SexpHash:
+		//good, required here
+		hash = a
+	default:
+		return fmt.Errorf("arg to generateSyntaxQuoteHash() must be a hash; got %T", a)
+	}
+	n := HashCountKeys(hash)
+	gen.AddInstruction(PushInstr{SexpMarker})
+	for i := 0; i < n; i++ {
+		// must reverse order here to preserve order on rebuild
+		key := (*hash.KeyOrder)[(n-i)-1]
+		val, err := hash.HashGet(key)
+		if err != nil {
+			return err
+		}
+		// value first, since value comes second on rebuild
+		gen.AddInstruction(PushInstr{SexpMarker})
+		gen.GenerateSyntaxQuote([]Sexp{val})
+		gen.AddInstruction(SquashInstr(0))
+		gen.AddInstruction(ExplodeInstr(0))
+
+		gen.AddInstruction(PushInstr{SexpMarker})
+		gen.GenerateSyntaxQuote([]Sexp{key})
+		gen.AddInstruction(SquashInstr(0))
+		gen.AddInstruction(ExplodeInstr(0))
+	}
+	gen.AddInstruction(HashizeInstr{
+		HashLen:  n,
+		TypeName: *(hash.TypeName),
+	})
+	return nil
 }

--- a/interpreter/generator.go
+++ b/interpreter/generator.go
@@ -258,7 +258,9 @@ func (gen *Generator) GenerateMacexpand(args []Sexp) error {
 	if err != nil {
 		return err
 	}
-	expr, err := gen.env.Apply(macro, macargs)
+
+	env := gen.env.Duplicate()
+	expr, err := env.Apply(macro, macargs)
 	if err != nil {
 		return err
 	}

--- a/interpreter/hashutils.go
+++ b/interpreter/hashutils.go
@@ -25,6 +25,29 @@ func HashExpression(expr Sexp) (int, error) {
 	return 0, errors.New(fmt.Sprintf("cannot hash type %T", expr))
 }
 
+func MapHash(env *Glisp, fun SexpFunction, hash SexpHash) (SexpArray, error) {
+	result := make([]Sexp, *hash.NumKeys)
+
+	var err error
+
+	i := 0
+
+	consPtr := make([]Sexp, 1)
+
+	for _, pairs := range hash.Map {
+		for _, pair := range pairs {
+			consPtr[0] = pair
+			result[i], err = env.Apply(fun, consPtr)
+			if err != nil {
+				return SexpArray(result), err
+			}
+			i++
+		}
+	}
+
+	return SexpArray(result), nil
+}
+
 func MakeHash(args []Sexp, typename string) (SexpHash, error) {
 	if len(args)%2 != 0 {
 		return SexpHash{},

--- a/interpreter/stack.go
+++ b/interpreter/stack.go
@@ -49,7 +49,7 @@ func (stack *Stack) PushAllTo(target *Stack) int {
 }
 
 func (stack *Stack) IsEmpty() bool {
-	return stack.tos == -1
+	return stack.tos < 0
 }
 
 func (stack *Stack) Push(elem StackElem) {

--- a/interpreter/typeutils.go
+++ b/interpreter/typeutils.go
@@ -19,6 +19,23 @@ func IsList(expr Sexp) bool {
 	return false
 }
 
+func IsPair(expr Sexp) bool {
+	switch list := expr.(type) {
+	case SexpPair:
+		if list.tail == SexpNull {
+			return false
+		}
+
+		switch ltail := list.tail.(type) {
+		case SexpPair:
+			return IsPair(ltail)
+		}
+
+		return true
+	}
+	return false
+}
+
 func IsFloat(expr Sexp) bool {
 	switch expr.(type) {
 	case SexpFloat:

--- a/interpreter/vm.go
+++ b/interpreter/vm.go
@@ -334,3 +334,96 @@ func (s SquashInstr) Execute(env *Glisp) error {
 	env.pc++
 	return nil
 }
+
+// bind these symbols to the SexpPair list found at
+// datastack top.
+type BindlistInstr struct {
+	syms []SexpSymbol
+}
+
+func (b BindlistInstr) InstrString() string {
+	joined := ""
+	for _, s := range b.syms {
+		joined += s.name + " "
+	}
+	return fmt.Sprintf("bindlist %s", joined)
+}
+
+func (b BindlistInstr) Execute(env *Glisp) error {
+	expr, err := env.datastack.PopExpr()
+	if err != nil {
+		return err
+	}
+
+	arr, err := ListToArray(expr)
+	if err != nil {
+		return err
+	}
+
+	nsym := len(b.syms)
+	narr := len(arr)
+	if narr < nsym {
+		return fmt.Errorf("bindlist failing: %d targets but only %d sources", nsym, narr)
+	}
+
+	for i, bindThisSym := range b.syms {
+		env.scopestack.BindSymbol(bindThisSym, arr[i])
+	}
+	env.pc++
+	return nil
+}
+
+type VectorizeInstr int
+
+func (s VectorizeInstr) InstrString() string {
+	return "vectorize"
+}
+
+func (s VectorizeInstr) Execute(env *Glisp) error {
+	vec := make([]Sexp, 0)
+
+	for {
+		expr, err := env.datastack.PopExpr()
+		if err != nil {
+			return err
+		}
+		if expr == SexpMarker {
+			break
+		}
+		vec = append([]Sexp{expr}, vec...)
+	}
+	env.datastack.PushExpr(SexpArray(vec))
+	env.pc++
+	return nil
+}
+
+type HashizeInstr struct {
+	HashLen  int
+	TypeName string
+}
+
+func (s HashizeInstr) InstrString() string {
+	return "hashize"
+}
+
+func (s HashizeInstr) Execute(env *Glisp) error {
+	a := make([]Sexp, 0)
+
+	for {
+		expr, err := env.datastack.PopExpr()
+		if err != nil {
+			return err
+		}
+		if expr == SexpMarker {
+			break
+		}
+		a = append(a, expr)
+	}
+	hash, err := MakeHash(a, s.TypeName)
+	if err != nil {
+		return err
+	}
+	env.datastack.PushExpr(hash)
+	env.pc++
+	return nil
+}

--- a/tests/eval.glisp
+++ b/tests/eval.glisp
@@ -1,0 +1,3 @@
+(assert (= (eval 3) 3))
+(assert (= (eval '(+ 1 2)) 3))
+(assert (= (eval '(begin 1 2 3)) 3))

--- a/tests/inc.g
+++ b/tests/inc.g
@@ -1,0 +1,3 @@
+
+(defn simple [] "from include")
+

--- a/tests/inc1.g
+++ b/tests/inc1.g
@@ -1,0 +1,2 @@
+
+(defn simple1 [] "from include 1")

--- a/tests/inc2.g
+++ b/tests/inc2.g
@@ -1,0 +1,3 @@
+; include2
+
+(defn inc2 [] "from inc2.g")

--- a/tests/inc3.g
+++ b/tests/inc3.g
@@ -1,0 +1,3 @@
+; include 3
+
+(defn inc3 [] "from inc3.g")

--- a/tests/include-source.glisp
+++ b/tests/include-source.glisp
@@ -14,3 +14,7 @@
 ; (println (simple))
 ; (println (simple1))
 
+(include "./tests/inc2.g" "./tests/inc3.g")
+
+(assert (= (inc2) "from inc2.g"))
+(assert (= (inc3) "from inc3.g"))

--- a/tests/include-source.glisp
+++ b/tests/include-source.glisp
@@ -1,0 +1,16 @@
+
+; (println "Here in base ")
+
+(source-file "./tests/inc.g" "./tests/inc1.g")
+
+; (println "Calling function defined in inc.g")
+
+(assert (= (simple) "from include"))
+
+; (println "Calling function defined in inc1.g")
+
+(assert (= (simple1) "from include 1"))
+
+; (println (simple))
+; (println (simple1))
+

--- a/tests/iterate.glisp
+++ b/tests/iterate.glisp
@@ -1,0 +1,37 @@
+; Test map iterations
+
+(def data {"a" 1 "b" 2})
+
+(defn assertPairs [x]
+	(assert (= true (pair? x))))
+
+(map assertPairs {"a" 1 "b" 2 "c" 3})
+
+(defn makeAssertMixed []
+	(let* [
+		x 	[0]
+		fun	(fn []
+				(begin
+					(aset! x 0 (+ (aget x 0) 1))
+					(cond
+						(= (aget x 0) 1)
+							(fn [z] (assert (= true (pair? z))))
+						(= (aget x 0) 2)
+							(fn [z] (assert (= true (hash? z))))
+						(= (aget x 0) 3)
+							(fn [z] (assert (= true (list? z))))
+						(assert false)
+					)
+				)
+			)
+		]
+		fun
+	)
+)
+
+
+(def mixGen (makeAssertMixed))
+
+
+(map (fn [x] ((mixGen) x)) [ ("a" "b" . "c") {"d" 1 "e" 2} '("f" "g" "h")] )
+

--- a/tests/macros.glisp
+++ b/tests/macros.glisp
@@ -10,3 +10,4 @@
 
 (assert (null? (when false 'c)))
 (assert (= 'a (when true 'c 'b 'a)))
+

--- a/tests/macros.glisp
+++ b/tests/macros.glisp
@@ -11,3 +11,9 @@
 (assert (null? (when false 'c)))
 (assert (= 'a (when true 'c 'b 'a)))
 
+(assert (=
+         '(cond false (begin (quote c)) (quote ()))
+         (macexpand (when false 'c))))
+(assert (=
+         '(cond true (begin (quote c) (quote b) (quote a)) (quote ()))
+         (macexpand (when true 'c 'b 'a))))

--- a/tests/syntax-quote.glisp
+++ b/tests/syntax-quote.glisp
@@ -1,0 +1,3 @@
+(def a 7)
+(def x `[{'g ({'b [~a]})}])
+(assert (= (str x) "[(hash (quote g) ((hash (quote b) [7])))]"))


### PR DESCRIPTION
Wanted to walk hashmaps like normal collections. Which also ended up need to know the incoming element was of a pair type.

Another implementation option would be maybe to make (hash->array) converter method then use map like normal. Not sure what would be more idiomatic.
